### PR TITLE
avoid using wb styles

### DIFF
--- a/R/PivotOpenXlsxRenderer.R
+++ b/R/PivotOpenXlsxRenderer.R
@@ -479,28 +479,27 @@ PivotOpenXlsxRenderer <- R6::R6Class("PivotOpenXlsxRenderer",
       }
 
       # set the minimum row heights
-      for(r in 1:length(private$p_minimumRowHeights)) {
-        if(private$p_minimumRowHeights[r] > 0) {
-          if(openxlsxVersion=="openxlsx") {
-            openxlsx::setRowHeights(wb, sheet=wsName, rows=r, heights=private$p_minimumRowHeights[r])
-          }
-          else if(openxlsxVersion=="openxlsx2") {
-            wb$set_row_heights(sheet=wsName, rows=r, heights=private$p_minimumRowHeights[r])
-          }
+      rows <- which(private$p_minimumRowHeights > 0)
+      if (length(rows)) {
+        offsetRows <- topRowNumber + columnGroupLevelCount + rows - 1 + rowOffsetDueToDummyColumn
+        if(openxlsxVersion=="openxlsx") {
+          openxlsx::setRowHeights(wb, sheet=wsName, rows=offsetRows, heights=private$p_minimumRowHeights[rows])
+        }
+        else if(openxlsxVersion=="openxlsx2") {
+          wb$set_row_heights(sheet=wsName, rows=offsetRows, heights=private$p_minimumRowHeights[rows])
         }
       }
 
       # set the minimum column widths
-      for(c in 1:private$p_maxColumnNumber) {
-        minColumnWidth <- private$p_minimumColumnWidths[c]
-        if (!is.null(openxlsxMinimumColumnWidth)) minColumnWidth <- max(minColumnWidth, openxlsxMinimumColumnWidth)
-        if(minColumnWidth > 0) {
-          if(openxlsxVersion=="openxlsx") {
-            openxlsx::setColWidths(wb, sheet=wsName, cols=c, widths=minColumnWidth)
-          }
-          else if(openxlsxVersion=="openxlsx2") {
-            wb$set_col_widths(sheet=wsName, cols=c, widths=minColumnWidth)
-          }
+      minColumnWidth <- max(private$p_minimumColumnWidths, openxlsxMinimumColumnWidth)
+      cols <- which(minColumnWidth > 0)
+      if (length(cols)) {
+        offsetCols <- cols + leftMostColumnNumber - 1L
+        if(openxlsxVersion=="openxlsx") {
+          openxlsx::setColWidths(wb, sheet=wsName, cols=offsetCols, widths=minColumnWidth[cols])
+        }
+        else if(openxlsxVersion=="openxlsx2") {
+          wb$set_col_widths(sheet=wsName, cols=offsetCols, widths=minColumnWidth[cols])
         }
       }
 

--- a/R/PivotOpenXlsxStyle.R
+++ b/R/PivotOpenXlsxStyle.R
@@ -444,6 +444,10 @@ PivotOpenXlsxStyle <- R6::R6Class("PivotOpenXlsxStyle",
     applyOpenXlsx2Style = function(wb, sheet, row, col) {
 
       # print(self$openxlsxStyle)
+      ox2font <- NULL
+      ox2fill <- NULL
+      ox2border <- NULL
+      ox2numfmt <- NULL
 
       bold <- ""
       underline <- ""
@@ -456,54 +460,60 @@ PivotOpenXlsxStyle <- R6::R6Class("PivotOpenXlsxStyle",
         if ("italic" %in% self$openxlsxStyle$textDecoration) italic <- TRUE
       }
 
-      dims <- openxlsx2::wb_dims(rows = row, cols = col)
-      wb$add_font(
-        sheet = sheet,
-        dims = dims,
+      dims <- paste0(mapply(openxlsx2::rowcol_to_dims, row, col, single = TRUE), collapse = ",")
+      if (dims == "") return(invisible(wb))
+
+      ox2font <- openxlsx2::create_font(
         name = self$openxlsxStyle$fontName,
-        size = self$openxlsxStyle$fontSize,
+        sz = self$openxlsxStyle$fontSize,
         colour = if(is.null(self$openxlsxStyle$fontColour)) openxlsx2::wb_colour(theme = 1) else openxlsx2::wb_colour(self$openxlsxStyle$fontColour),
-        bold = bold,
-        underline = underline,
+        b = bold,
+        u = underline,
         strike = strikethrough,
-        italic = italic
+        i = italic
       )
+      wb$styles_mgr$add(ox2font, ox2font)
+
       if (!is.null(self$openxlsxStyle$fgFill)) {
-        wb$add_fill(
-          sheet = sheet,
-          dims = dims,
-          colour = openxlsx2::wb_colour(self$openxlsxStyle$fgFill)
+        ox2fill <- openxlsx2::create_fill(
+          pattern_type = "solid",
+          fg_colour = openxlsx2::wb_colour(self$openxlsxStyle$fgFill)
         )
+        wb$styles_mgr$add(ox2fill, ox2fill)
       }
       if (!is.null(self$openxlsxStyle$border)) {
-        wb$add_border(
-          sheet = sheet,
-          dims = dims,
-          left_border = self$openxlsxStyle$borderStyle[1],
-          right_border = self$openxlsxStyle$borderStyle[2],
-          top_border = self$openxlsxStyle$borderStyle[3],
-          bottom_border = self$openxlsxStyle$borderStyle[4],
+        ox2border <- openxlsx2::create_border(
+          left = self$openxlsxStyle$borderStyle[1],
+          right = self$openxlsxStyle$borderStyle[2],
+          top = self$openxlsxStyle$borderStyle[3],
+          bottom = self$openxlsxStyle$borderStyle[4],
           left_color = openxlsx2::wb_colour(self$openxlsxStyle$borderColour[1]),
           right_color = openxlsx2::wb_colour(self$openxlsxStyle$borderColour[2]),
           top_color = openxlsx2::wb_colour(self$openxlsxStyle$borderColour[3]),
           bottom_color = openxlsx2::wb_colour(self$openxlsxStyle$borderColour[4])
         )
+        wb$styles_mgr$add(ox2border, ox2border)
       }
       if (self$openxlsxStyle$numFmt != "GENERAL") {
-        wb$add_numfmt(
-          sheet = sheet,
-          dims = dims,
+        ox2numfmt <- openxlsx2::create_numfmt(
           numfmt = self$openxlsxStyle$numFmt
         )
+        wb$styles_mgr$add(ox2numfmt, ox2numfmt)
       }
-      wb$add_cell_style(
-        sheet = sheet,
-        dims = dims,
-        text_rotation = if (!is.null(self$openxlsxStyle$textRotation)) self$openxlsxStyle$textRotation else NULL,
-        horizontal = if (!is.null(self$openxlsxStyle$halign)) self$openxlsxStyle$halign else NULL,
-        vertical = if (!is.null(self$openxlsxStyle$valign)) self$openxlsxStyle$valign else NULL,
-        wrap_text = if (!is.null(self$openxlsxStyle$wrapText)) self$openxlsxStyle$wrapText else NULL
+
+      ox2cell <- openxlsx2::create_cell_style(
+        text_rotation = if (!is.null(self$openxlsxStyle$textRotation)) self$openxlsxStyle$textRotation else "",
+        horizontal = if (!is.null(self$openxlsxStyle$halign)) self$openxlsxStyle$halign else "",
+        vertical = if (!is.null(self$openxlsxStyle$valign)) self$openxlsxStyle$valign else "",
+        wrap_text = if (!is.null(self$openxlsxStyle$wrapText)) self$openxlsxStyle$wrapText else "",
+        font_id = if (!is.null(wb$styles_mgr$get_font_id(ox2font))) wb$styles_mgr$get_font_id(ox2font) else "",
+        fill_id = if (!is.null(wb$styles_mgr$get_fill_id(ox2fill))) wb$styles_mgr$get_fill_id(ox2fill) else "",
+        num_fmt_id = if (!is.null(wb$styles_mgr$get_numfmt_id(ox2numfmt))) wb$styles_mgr$get_numfmt_id(ox2numfmt) else "",
+        border_id = if (!is.null(wb$styles_mgr$get_border_id(ox2border))) wb$styles_mgr$get_border_id(ox2border) else ""
       )
+      wb$styles_mgr$add(ox2cell, ox2cell)
+
+      wb$set_cell_style(dims = dims, style = wb$styles_mgr$get_xf_id(ox2cell))
 
       invisible(wb)
     },

--- a/R/PivotOpenXlsxStyle.R
+++ b/R/PivotOpenXlsxStyle.R
@@ -470,7 +470,8 @@ PivotOpenXlsxStyle <- R6::R6Class("PivotOpenXlsxStyle",
         b = bold,
         u = underline,
         strike = strikethrough,
-        i = italic
+        i = italic,
+        scheme = ""
       )
       wb$styles_mgr$add(ox2font, ox2font)
 
@@ -496,7 +497,7 @@ PivotOpenXlsxStyle <- R6::R6Class("PivotOpenXlsxStyle",
       }
       if (self$openxlsxStyle$numFmt != "GENERAL") {
         ox2numfmt <- openxlsx2::create_numfmt(
-          numfmt = self$openxlsxStyle$numFmt
+          formatCode = self$openxlsxStyle$numFmt
         )
         wb$styles_mgr$add(ox2numfmt, ox2numfmt)
       }


### PR DESCRIPTION
Your previous comments gave me something to think, but thinking wasn't easy this week - was a bit under the weather. Basically, this is related to a PR in `openxlsx2` that I'm about to merge in a wee while. The `wb_add_*` functions of `openxlsx2` alter the contents of a single cell again and again and again. So applying fonts, fills, numfmt, borders and cell styles all changes the same cells. And for each cell we do a check first, if there's a style that we can add to. Like, if the cell is filled in blue and we want to add a border, then lets add the border on top of the blue cell.

Usually that's no problem, if the styling is applied just once over a cell range, but for the specifics of the `pivottabler` implementation it is applied multiple times on each cell. If there are 5 changes to apply, a font, a numfmt, a fill and a border, and centering, the cell is touched not once, but 5 times. And that's a bit overkill. Also I assume that `pivottabler` does not want to preserve previous cell content, hence we can use the what I like to call "bare metal approach" to styles. This way the function only tries only once to apply a style to a cell.

The issue though, we still have to try a couple of times per cell if we can apply a cell style and if we can reuse parts of a previous cell style. This would probably be a lot quicker, if the `pivottabler` implementation would decide on unique cell elements ahead of their application. E.g. if a single font is used across multiple cells, we do not have to check n-times if the font is already available in the workbook, but could use it just straight away.

Given that we do not have this, the `openxlsx2` implementation is currently a bit slower. But then again, I'm not losing sleep over 90ms.

``` r
library(pivottabler)
pt <- PivotTable$new()
pt$addData(bhmtrains)
pt$addColumnDataGroups("TrainCategory")
pt$addRowDataGroups("TOC")
pt$defineCalculation(calculationName="TotalTrains", summariseExpression="n()")
pt$evaluatePivot()
pt$mapStyling(cells=pt$allCells, styleProperty="background-color", 
              valueType="color", mapType="logic",
              mappings=list("v==3079", "skyblue", "v<1000", "orange", 
                            "5000<=v<15000", "yellow", "v>50000", "green"))
pt$mapStyling(cells=pt$allCells, styleProperty="color", valueType="color", 
              mapType="logic", mappings=list("v>50000", "white"))
pt$mapStyling(cells=pt$allCells, styleProperty="background-color", 
              valueType="text", mapType="logic",
              mappings=list("is.null(v)", "red"))
if (interactive()) pt$renderPivot()

old <- function() {
  wb <- openxlsx::createWorkbook()
  openxlsx::addWorksheet(wb, "Data")
  pt$writeToExcelWorksheet(wb=wb, wsName="Data", 
                           topRowNumber=2, leftMostColumnNumber=2, applyStyles=TRUE)
  # openxlsx::openXL(wb)
}

new <- function() {
  wb <- openxlsx2::wb_workbook(creator = Sys.getenv("USERNAME")) |>
    openxlsx2::wb_add_worksheet("Data", grid_lines = FALSE)
  pt$writeToExcelWorksheet(wb=wb, wsName="Data", 
                           topRowNumber=2, leftMostColumnNumber=2, applyStyles=TRUE)
  # if (interactive()) wb$open()
}

res <- microbenchmark::microbenchmark(
  old(),
  new(), 
  times = 25
); res
#> Warning in microbenchmark::microbenchmark(old(), new(), times = 25): less
#> accurate nanosecond times to avoid potential integer overflows
#> Unit: milliseconds
#>   expr      min       lq     mean   median       uq       max neval
#>  old() 134.9001 142.1522 187.4008 145.5678 239.6696  500.8284    25
#>  new() 224.6160 226.5624 277.7252 231.2615 241.1203 1002.9071    25
``` 